### PR TITLE
verify container when render tree into container

### DIFF
--- a/src/ReactDOM.js
+++ b/src/ReactDOM.js
@@ -1,13 +1,31 @@
 import * as _ from './util'
-import { COMPONENT_ID, VELEMENT, VCOMPONENT } from './constant'
+import {
+	COMPONENT_ID,
+	VELEMENT,
+	VCOMPONENT,
+	ELEMENT_NODE_TYPE,
+	DOC_NODE_TYPE,
+	DOCUMENT_FRAGMENT_NODE_TYPE
+} from './constant'
 import { initVnode, destroyVnode, clearPending, compareTwoVnodes } from './virtual-dom'
 import { updateQueue } from './Component'
+
+function isValidContainer(node) {
+    return !!(node && (
+        node.nodeType === ELEMENT_NODE_TYPE ||
+        node.nodeType === DOC_NODE_TYPE ||
+        node.nodeType === DOCUMENT_FRAGMENT_NODE_TYPE
+    ))
+}
 
 let pendingRendering = {}
 let vnodeStore = {}
 function renderTreeIntoContainer(vnode, container, callback, parentContext) {
 	if (!vnode.vtype) {
 		throw new Error(`cannot render ${ vnode } to container`)
+	}
+	if (!isValidContainer(container)) {
+		throw new Error(`container ${container} is not a DOM element`)
 	}
 	let id = container[COMPONENT_ID] || (container[COMPONENT_ID] = _.getUid())
 	let argsCache = pendingRendering[id]
@@ -53,7 +71,7 @@ function renderTreeIntoContainer(vnode, container, callback, parentContext) {
 	} else if (vnode.vtype === VCOMPONENT) {
 		result = rootNode.cache[vnode.uid]
 	}
-	
+
 	if (!isPending) {
 		updateQueue.isPending = false
 		updateQueue.batchUpdate()
@@ -62,7 +80,7 @@ function renderTreeIntoContainer(vnode, container, callback, parentContext) {
 	if (callback) {
 		callback.call(result)
 	}
-	
+
 	return result
 }
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -12,3 +12,6 @@ export const VCOMMENT = 5
 export const CREATE = 1
 export const REMOVE = 2
 export const UPDATE = 3
+export const ELEMENT_NODE_TYPE = 1
+export const DOC_NODE_TYPE = 9
+export const DOCUMENT_FRAGMENT_NODE_TYPE = 11


### PR DESCRIPTION
When invoke `ReactDOM.render`, I get the error:

```js
ReactDOM.render(<MyComponent />, document.getElementById('container'))


Uncaught TypeError: Cannot read property 'liteid' of null
```

The error message is not very clear to figure out what's wrong.

And finally I get it out: the container is null (not exists).

So it's better to verify `container` when invoke `ReactDOM.render(component, container, cb?)`. (And `React` do verify)