### PR TITLE
Fixed  "Can not read property '$ updater' of undefined"

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -140,7 +140,7 @@ Component.prototype = {
 	// },
 	forceUpdate(callback) {
 		let { $updater, $cache, props, state, context } = this
-		if (!$cache.isMounted) {
+		if ($updater.isPending || !$cache.isMounted) {
 			return
 		}
 		let nextProps = $cache.props || props


### PR DESCRIPTION
Scenes: React-lite is used with Redux, and React components use Redux to bind state.
Behavior: dispatch an action in the componentWillReceiveProps or componentDidUpdate methods of the React component to modify the state of the binding.
Exception: error Can not read property '$ updater' of undefined

Fixed this Bug