### PR TITLE
Don't blow up when the DOM is modified

### DIFF
--- a/src/virtual-dom.js
+++ b/src/virtual-dom.js
@@ -204,6 +204,8 @@ function collectChild(child, children) {
 }
 
 function diffVchildren(patches, vnode, newVnode, node, parentContext) {
+    if (!node.vchildren) return // react-lite hasn't seen this DOM node before
+
     let { childNodes, vchildren } = node
     let newVchildren = node.vchildren = getFlattenChildren(newVnode)
     let vchildrenLen = vchildren.length


### PR DESCRIPTION
resolves https://github.com/Lucifier129/react-lite/issues/90

I suspect there's a possible memory leak, so we could warn here as well. Either way, this is an elegant fix to the problem in https://github.com/Lucifier129/react-lite/issues/90.