### PR TITLE
remove generic reference to Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 react-lite is an implementation of React that optimizes for small script size.
-### Framework Size Comparison
+### Size Comparison
 
 | Framework              | Version    | Minified Size |
 |------------------------|------------|---------------|


### PR DESCRIPTION
As an industry we misuse the word "framework". 

React is not a framework. It is a library. The creators of React are adamant about this. They just put the "V" in MVC.
Riot is not a framework. It is a library.
Web Components polyfill is a polyfill.